### PR TITLE
Document mod-c/copy current block ref

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -237,7 +237,7 @@
      :binding "shift+tab"
      :fn      (editor-handler/keydown-tab-handler :left)}
     :editor/copy
-    {:desc    "Copy"
+    {:desc    "Copy (copies either selection, or block reference)"
      :binding "mod+c"
      :fn      editor-handler/shortcut-copy}
     :editor/cut


### PR DESCRIPTION
This is not documented in the default key descriptions:

When in edit mode but no text selected, copy current block ref (/src/main/frontend/handler/editor.cljs)