### PR TITLE
Fix css time element

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1152,3 +1152,17 @@ html[data-theme='dark'] .keyboard-shortcut > code {
 .overflow-y-scroll {
     overflow-y: scroll;
 }
+
+/* Fix time css element */
+time {
+  margin-right: 5px;
+  font-family: monospace;
+}
+
+.is-paragraph {
+  display: inline;
+}
+
+.raw_html {
+  display: inline;
+}


### PR DESCRIPTION
Using `<time>11:22</time>message` results in:
```
11:22
message
```
This is because of two divs that default to block. margin and font-family for minimal extra styling.

Fixes #2843